### PR TITLE
Empty request bodies now return 422 and removed stack trace from one error message (on POST and PATCH)

### DIFF
--- a/NCS.DSS.Diversity/NCS.DSS.Diversity.csproj
+++ b/NCS.DSS.Diversity/NCS.DSS.Diversity.csproj
@@ -6,9 +6,6 @@
 		<ImplicitUsings>enable</ImplicitUsings>
 	</PropertyGroup>
 	<ItemGroup>
-	  <Content Include="local.settings.json" />
-	</ItemGroup>
-	<ItemGroup>
 		<PackageReference Include="Azure.Messaging.ServiceBus" Version="7.18.1" />		
 		<PackageReference Include="DFC.HTTP.Standard" Version="0.1.11" />
 		<PackageReference Include="DFC.JSON.Standard" Version="0.1.4" />

--- a/NCS.DSS.Diversity/NCS.DSS.Diversity.csproj
+++ b/NCS.DSS.Diversity/NCS.DSS.Diversity.csproj
@@ -6,6 +6,9 @@
 		<ImplicitUsings>enable</ImplicitUsings>
 	</PropertyGroup>
 	<ItemGroup>
+		<Content Include="local.settings.json" />
+	</ItemGroup>
+	<ItemGroup>
 		<PackageReference Include="Azure.Messaging.ServiceBus" Version="7.18.1" />		
 		<PackageReference Include="DFC.HTTP.Standard" Version="0.1.11" />
 		<PackageReference Include="DFC.JSON.Standard" Version="0.1.4" />

--- a/NCS.DSS.Diversity/PatchDiversityHttpTrigger/Function/PatchDiversityHttpTrigger.cs
+++ b/NCS.DSS.Diversity/PatchDiversityHttpTrigger/Function/PatchDiversityHttpTrigger.cs
@@ -1,3 +1,4 @@
+using Azure.Core;
 using DFC.HTTP.Standard;
 using DFC.Swagger.Standard.Annotations;
 using Microsoft.AspNetCore.Http;
@@ -105,6 +106,12 @@ namespace NCS.DSS.Diversity.PatchDiversityHttpTrigger.Function
                 _logger.LogInformation("Attempting to retrieve resource from request. Correlation GUID: {CorrelationGuid}", correlationGuid);
                 diversityPatchRequest = await _httpRequestHelper.GetResourceFromRequest<Models.DiversityPatch>(req);
 
+                if (diversityPatchRequest == null)
+                {
+                    _logger.LogWarning("{diversityPatchRequest} object is NULL. Correlation GUID: {CorrelationGuid}", nameof(diversityPatchRequest), correlationGuid);
+                    return new UnprocessableEntityObjectResult("Diversity Details in request body are NULL. Please supply this data.");
+                }
+
                 // Fix for bug AD-157065 (Oct '23)
                 if (diversityPatchRequest.ConsentToCollectEthnicity == null)
                     diversityPatchRequest.ConsentToCollectEthnicity = false;
@@ -114,14 +121,8 @@ namespace NCS.DSS.Diversity.PatchDiversityHttpTrigger.Function
             }
             catch (JsonException ex)
             {
-                _logger.LogError(ex, "Unable to parse {diversityPatchRequest} from request body. Correlation GUID: {CorrelationGuid}. Exception: {ExceptionMessage}", nameof(diversityPatchRequest), correlationGuid, ex.Message);
-                return new UnprocessableEntityObjectResult(_dynamicHelper.ExcludeProperty(ex, PropertyToExclude));
-            }
-
-            if (diversityPatchRequest == null)
-            {
-                _logger.LogWarning("{diversityPatchRequest} object is NULL. Correlation GUID: {CorrelationGuid}", nameof(diversityPatchRequest), correlationGuid);
-                return new UnprocessableEntityObjectResult(req);
+                _logger.LogWarning(ex, "Unable to parse {diversityPatchRequest} from request body. Correlation GUID: {CorrelationGuid}. Exception: {ExceptionMessage}", nameof(diversityPatchRequest), correlationGuid, ex.Message);
+                return new UnprocessableEntityObjectResult("Unable to parse Diversity Details from request body.");
             }
 
             diversityPatchRequest.LastModifiedBy = touchpointId;

--- a/NCS.DSS.Diversity/PostDiversityHttpTrigger/Function/PostDiversityHttpTrigger.cs
+++ b/NCS.DSS.Diversity/PostDiversityHttpTrigger/Function/PostDiversityHttpTrigger.cs
@@ -98,6 +98,12 @@ namespace NCS.DSS.Diversity.PostDiversityHttpTrigger.Function
                 _logger.LogInformation("Attempting to retrieve resource from request. Correlation GUID: {CorrelationGuid}", correlationGuid);
                 diversityRequest = await _httpRequestHelper.GetResourceFromRequest<Models.Diversity>(req);
 
+                if (diversityRequest == null)
+                {
+                    _logger.LogWarning("{diversityRequest} object is NULL. Correlation GUID: {CorrelationGuid}\", nameof(diversityRequest), correlationGuid");
+                    return new UnprocessableEntityObjectResult("Diversity Details in request body are NULL. Please supply this data.");
+                }
+
                 // Fix for bug AD-157065 (Oct '23)
                 if (diversityRequest.ConsentToCollectEthnicity == null)
                     diversityRequest.ConsentToCollectEthnicity = false;
@@ -108,13 +114,7 @@ namespace NCS.DSS.Diversity.PostDiversityHttpTrigger.Function
             catch (JsonException ex)
             {
                 _logger.LogError(ex, "Unable to parse {diversityRequest} from request body. Correlation GUID: {CorrelationGuid}. Exception: {ExceptionMessage}", nameof(diversityRequest), correlationGuid, ex.Message);
-                return new UnprocessableEntityObjectResult(_dynamicHelper.ExcludeProperty(ex, PropertyToExclude));
-            }
-
-            if (diversityRequest == null)
-            {
-                _logger.LogWarning("{diversityRequest} object is NULL. Correlation GUID: {CorrelationGuid}", nameof(diversityRequest), correlationGuid);
-                return new UnprocessableEntityObjectResult(req);
+                return new UnprocessableEntityObjectResult("Unable to parse Diversity Details from request body.");
             }
 
             diversityRequest.SetIds(customerGuid, touchpointId);

--- a/Resources/template.json
+++ b/Resources/template.json
@@ -72,7 +72,7 @@
                 "CustomerDatabaseId": "customers",
                 "CustomerCollectionId": "customers",
                 "ServiceBusConnectionString": "[parameters('serviceBusConnectionString')]",
-                "QueueName": "[parameters('serviceBusQueueName')]",
+                "QueueName": "[parameters('serviceBusQueueName')]"
             },
             "copy": {
                 "name": "FunctionAppSettingsCopy",


### PR DESCRIPTION
- Moved NULL check to right after GetResourceFromRequest() invocation so that a 422 code is returned instead of 500 when the request bodies on POST and PATCH are NULL
- Removed the stack trace errors from line 117 on POST and line 125 from PATCH. These error messages are to take precedence over those in AD-206154-v3 in case there is a merge conflict between the two branches
- Removed comma from template file as it caused failure in build pipeline